### PR TITLE
Don't barf on duplicate broadcast addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,5 +120,6 @@ function getBroadcastAddresses () {
       }
     })
   })
-  return result
+  const uniq_results = [ ...new Set(result) ]
+  return uniq_results
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/udp-nmea-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "UDP NMEA0183 Sender",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Apparently bridged interfaces can have same broadcast addresses, which cannot be used in the same enum. This PR simply deduplicates the constructed broadcast address list.