### PR TITLE
fix: use local socket per destination to prevent EBADF with multiple destinations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,6 @@ const isDestinationConfigs = (
 }
 
 module.exports = function (app: ServerAPI) {
-  let socket: dgram.Socket
   let onStop = new Array<OnStopHandler>()
   const setStatus = app.setPluginStatus
   const setStatusError = app.setPluginError
@@ -45,15 +44,18 @@ module.exports = function (app: ServerAPI) {
     app.debug(JSON.stringify(options))
     const address = options.ipaddress || options.broadcastAddress
     if (address && address != '-') {
-      socket = dgram.createSocket('udp4')
-      socket.bind(Number(address), function () {
-        socket.setBroadcast(true)
+      const sock = dgram.createSocket('udp4')
+      sock.bind(0, function () {
+        sock.setBroadcast(true)
+      })
+      onStop.push(() => {
+        try { sock.close() } catch (e) { /* already closed */ }
       })
 
       const delimiter = DELIMITERS[options.lineDelimiter || ''] || ''
       const send = (message: string) => {
         const msg = `${message}${delimiter}`
-        socket.send(msg, 0, msg.length, Number(options.port), address)
+        sock.send(msg, 0, msg.length, Number(options.port), address)
       }
       if (typeof options.nmea0183 === 'undefined' || options.nmea0183) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -100,10 +102,6 @@ module.exports = function (app: ServerAPI) {
     stop: () => {
       onStop.forEach(f => f())
       onStop = []
-      if (socket) {
-        socket.close()
-        socket = undefined
-      }
     },
     schema,
     id: 'udp-nmea-sender',


### PR DESCRIPTION
## Problem

When configuring multiple destinations in the plugin, the shared `socket` variable causes a race condition that results in an `EBADF` error on `setBroadcast()`.

The issue is in `startDestination()`:

1. Destination 1 calls `socket = dgram.createSocket('udp4')` → assigns socket1
2. Destination 1 calls `socket.bind(...)` with an async callback
3. Destination 2 calls `socket = dgram.createSocket('udp4')` → **overwrites** socket1 with socket2
4. Destination 1's bind callback fires and calls `socket.setBroadcast(true)` — but `socket` now points to socket2, which may not be bound yet → **EBADF**

There is also a secondary issue: `socket.bind(Number(address))` where `address` is a broadcast IP like `"192.168.2.255"`. `Number("192.168.2.255")` evaluates to `NaN`, which is not a valid port number.

## Fix

- Replace the shared `let socket` with a `const sock` local to each `startDestination()` call. Each destination now gets its own independent socket, eliminating the race condition.
- Change `socket.bind(Number(address), ...)` to `sock.bind(0, ...)`. Port 0 lets the OS assign an ephemeral source port. The destination address is already correctly passed to `sock.send()`.
- Move socket cleanup (`sock.close()`) into the `onStop` array so each socket is properly closed when the plugin stops, instead of only closing the last one via the shared variable.

## Testing

Tested on a Raspberry Pi Zero 2W running SignalK v2.26.0 with two network interfaces (wlan0 + hotspot uap0), broadcasting NMEA0183 sentences to both subnets simultaneously on port 2000. Confirmed working with no errors.